### PR TITLE
Remove nut.cc from the list

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers.txt
+++ b/easyprivacy/easyprivacy_trackingservers.txt
@@ -2577,7 +2577,6 @@
 ||nfwebminer.com^$third-party
 ||niematego.tk^$third-party
 ||noblock.pro^$third-party
-||nut.cc^$third-party
 ||ogrid.org^$third-party
 ||okeyletsgo.ml^$third-party
 ||onlinereserchstatistics.online^$third-party


### PR DESCRIPTION
nut.cc is a free domain provider. Websites just taking advantage of a free domain should not be blocked.

If there's a more specific reason why nut.cc is blocked, let me know.